### PR TITLE
 [SPARK-33152][SQL][2.4] Constraint Propagation code causes OOM issue…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ConstraintSet.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ConstraintSet.scala
@@ -1,0 +1,751 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+import scala.collection.{mutable, GenSet, GenTraversableOnce}
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * This class stores the constraints available at each node.
+ * The constraint expressions are stored in canonicalized form.
+ * The major way in which it differs from the [[ExpressionSet]] is that
+ * in case of Project Node, it stores information about the aliases
+ * and groups them on the basis of equivalence. In stock spark all the
+ * constraints are pre-created pessimistically for all possible combinations
+ * of equivalent aliases. While in this class only one constraint per filter
+ * is present & the rest are created in expand function at the time of
+ * new filter inference. Also even then, not all combinations are created,
+ * instead one filter constraint for each alias in the group is created.
+ *
+ * The core logic of new algorithm is as follows
+ * The base constraints present in this object will always be composed of
+ * as far as possible, of those attributes which were present in the incoming
+ * set & are also part of the output set for the node. If any attribute or expression
+ * is part of any outgoing alias, they will be added to either attribute equivalence list
+ * or expression equivalence list, depending upon whether the Alias's child is attribute
+ * or generic expression. The 0th element of each of the buffer in the attribute equivalence
+ * list & expression equivalence list are special in the sense, that any constraint,
+ * if it is referring to any attribute or expression in the two lists, is guaranteed to
+ * use the 0th element and not any other members. An attempt is made to ensure that the
+ * constraint survives when bubbling up. If an attribute or expression, which is part
+ * of incoming constraint, but is not present in output set, makes the survival of the
+ * constraint susceptible. In such case, the attribute equivalence list & expression
+ * equivalence list are consulted & if found that the buffer containing 0th element as
+ * the attribute which is getting removed, has another element, then that element ( the
+ * 1th member) is chosen to replace the attribute being removed  in the constraint.
+ * The constraint is updated to use the 1th element. This 1th element is then put in
+ * 0th place of the buffer.
+ * It is to be noted that attribute equivalence list will have buffers where each
+ * element will be of type attribute only. While expression equivalence list will
+ * have 0th element as of type generic expression, rest being attributes.
+ * It is also to be noted, that the 0th element of expression equivalence list being
+ * generic expression, itself is composed of attributes. And the expression equivalence
+ * list needs to be updated, if any of the attribute it refers to is being eliminated
+ * from the output set.
+ *
+ * For eg. consider an existing constraint a + b + c + d > 7
+ * let the input set comprise of attributes a, b, c, d
+ * Let the output set be  a, a as a1, a as a2, b + c as z, d as d1
+ * In the above d , b  & c are getting eliminated
+ * while a survives and also has a1 & a2.
+ * d is referred as d1.
+ * the initial attribute equivalence list will be
+ * a, a1, a2
+ * d, d1
+ * expression equivalence list will be
+ * b + c , z
+ * Now for the constraint a + b + c + d > 7 to survive
+ * b + c => can be replaced by z
+ * d can be replaced by d1
+ * so the constraint will be updated as
+ * a + z + d1 > 7
+ * the updated attribute equivalence list will be
+ * a, a1, a2
+ * since d1 will be left alone, it will no longer be part of the list
+ * same is the case with expression equivalence list.
+ * as b + c, will be removed, only z1 remains, so it will be removed
+ * from expression equivalence list & it will be empty.
+ *
+ * @param baseSet    [[mutable.Set[Expression]] which contains Canonicalized Constraint Expression
+ * @param originals    [[mutable.Buffer[Expression]] buffer containing the original constraint
+ *                   expression
+ * @param attribRefBasedEquivalenceList    A List of List which contains grouping of equivalent
+ *                   Aliases referring to same Attribute
+ * @param expressionBasedEquivalenceList     A List of List which contains grouping of equivalent
+ *  Aliases referring to same Expression( which is not an Attribute)
+ */
+
+class ConstraintSet private(
+  baseSet: mutable.Set[Expression],
+  originals: mutable.Buffer[Expression] = new ArrayBuffer,
+  val attribRefBasedEquivalenceList: Seq[mutable.Buffer[Expression]],
+  val expressionBasedEquivalenceList: Seq[mutable.Buffer[Expression]]
+) extends ExpressionSet(baseSet, originals) {
+
+  def this(actuals: mutable.Buffer[Expression]) =
+    this(actuals.map(_.canonicalized).to[mutable.Set], actuals,
+      Seq.empty[mutable.Buffer[Expression]], Seq.empty[mutable.Buffer[Expression]])
+
+  def this(
+    actuals: mutable.Buffer[Expression],
+    attribRefBasedEquivalenceList: Seq[mutable.Buffer[Expression]],
+    expressionBasedEquivalenceList: Seq[mutable.Buffer[Expression]]) =
+    this(actuals.map(_.canonicalized).to[mutable.Set], actuals, attribRefBasedEquivalenceList,
+      expressionBasedEquivalenceList)
+
+  def this(baseSet: mutable.Set[Expression], actuals: mutable.Buffer[Expression]) =
+    this(baseSet, actuals, Seq.empty[mutable.Buffer[Expression]],
+      Seq.empty[mutable.Buffer[Expression]])
+
+  def this() = this(mutable.Buffer.empty[Expression])
+
+  override def +(elem: Expression): ConstraintSet = {
+    val newSet = new ConstraintSet(baseSet.clone(), this.originals.clone(),
+      this.attribRefBasedEquivalenceList.map(_.clone),
+      this.expressionBasedEquivalenceList.map(_.clone))
+    // If the constraint is already present in canonicalized form do not add
+    val conditionedElement = convertToCanonicalizedIfRequired(elem)
+    if (!this.contains(conditionedElement)) {
+      newSet.add(conditionedElement)
+    }
+    newSet
+  }
+
+  override def union(that: GenSet[Expression]): ConstraintSet = {
+    that match {
+      case thatX: ConstraintSet =>
+        val newSet = super.union(that).asInstanceOf[ConstraintSet]
+        new ConstraintSet(
+          newSet.baseSet,
+          newSet.originals,
+          newSet.attribRefBasedEquivalenceList ++ thatX.attribRefBasedEquivalenceList,
+          newSet.expressionBasedEquivalenceList ++ thatX.expressionBasedEquivalenceList
+        )
+      case _ => super.union(that).asInstanceOf[ConstraintSet]
+    }
+  }
+
+  override def ++(elems: GenTraversableOnce[Expression]): ConstraintSet = {
+    val newSet = new ConstraintSet(baseSet.clone(), originals.clone(),
+      this.attribRefBasedEquivalenceList.map(_.clone),
+      this.expressionBasedEquivalenceList.map(_.clone))
+    elems.foreach(ele => {
+      val conditionedElement = convertToCanonicalizedIfRequired(ele)
+      if (!this.contains(conditionedElement)) {
+        newSet.add(conditionedElement)
+      }
+    })
+    newSet
+  }
+
+  override def convertToCanonicalizedIfRequired(ele: Expression): Expression = {
+    val suspectAttribs = ele.references.toSet --
+      this.attribRefBasedEquivalenceList.map(buff => buff.head.asInstanceOf[Attribute])
+    if (suspectAttribs.isEmpty) {
+      ele
+    } else {
+      val mappings = suspectAttribs.map(attrib =>
+        (this.attribRefBasedEquivalenceList ++ this.expressionBasedEquivalenceList).find(
+          buff => buff.exists(_.canonicalized == attrib.canonicalized)).
+          map(buff => attrib -> Option(buff.head)).getOrElse(attrib -> None)).toMap
+      ele.transformUp {
+        case attr: Attribute if mappings.contains(attr) => mappings(attr).getOrElse(attr)
+      }
+    }
+  }
+
+  override def -(elem: Expression): ConstraintSet = {
+    if (elem.deterministic) {
+      val newBaseSet = baseSet.clone().filterNot(_ == elem.canonicalized)
+      val newOriginals =
+        originals.clone().filterNot(_.canonicalized == elem.canonicalized)
+      new ConstraintSet(newBaseSet, newOriginals, this.attribRefBasedEquivalenceList.map(_.clone),
+        this.expressionBasedEquivalenceList.map(_.clone))
+    } else {
+      new ConstraintSet(baseSet.clone(), originals.clone(),
+        this.attribRefBasedEquivalenceList.map(_.clone),
+        this.expressionBasedEquivalenceList.map(_.clone))
+    }
+  }
+
+  /**
+   * This function updates the existing non redundant, non trivial constraints stored
+   * as per the basis of incoming attributes and outgoing attributes of the node.
+   * If the attributes forming the constraints are not going to be part of the output set,
+   * then attempt is made ,as much as possible, to see if the constraint can survive
+   * by modifying it with 1st available alias for the attribute getting removed.
+   * It also tracks the aliases of the attribute which are then used to generate
+   * redundant constraints in the expand function & for pruning in the contains function
+   *
+   * @param outputAttribs The attributes which are part of the output set
+   * @param inputAttribs The attributes which make up the incoming attributes
+   * @param projectList The list of projections containing the NamedExpression
+   * @param oldAliasedConstraintsCreator A partial function used for generating all
+   *                                     combination of constraints as per old code.
+   *                                     Used only when the un optimized constraint propagation
+   *                                     is used. Used in ExpressionSet
+   * @return The new valid ConstraintSet
+   */
+  override def updateConstraints(outputAttribs: Seq[Attribute],
+    inputAttribs: Seq[Attribute], projectList: Seq[NamedExpression],
+    oldAliasedConstraintsCreator: Option[Seq[NamedExpression] => Set[Expression]]):
+  ConstraintSet = {
+    val (aliasBased, _) = projectList.partition {
+      case _: Alias => true
+      case _ => false
+    }
+    val groupHeadToGroupMap: ExpressionMap[mutable.Buffer[Expression]] =
+      new ExpressionMap[mutable.Buffer[Expression]]()
+
+    this.attribRefBasedEquivalenceList.foreach(x =>
+      groupHeadToGroupMap += (x.head -> x.clone())
+    )
+    this.expressionBasedEquivalenceList.foreach(x =>
+      groupHeadToGroupMap += (x.head -> x.clone())
+    )
+    // clone the keys so that the set obtained is static & detached from
+    // the groupHeadToGroupMap
+    val existingAttribGroupHead = groupHeadToGroupMap.keySet.toSet
+
+    // add the incoming attribs list
+    aliasBased.foreach( ne => ne match {
+      case al: Alias =>
+        // find the group to which this alias's child belongs to
+        // if the child is an attribute
+        val alChild = al.child
+        val key = this.attribRefBasedEquivalenceList
+          .find(_.exists(_.canonicalized == alChild.canonicalized)).map(_.head)
+          .getOrElse(this.expressionBasedEquivalenceList.find(buff =>
+            buff.exists(_.canonicalized == alChild.canonicalized)).map(_.head).getOrElse(alChild))
+
+        groupHeadToGroupMap.get(key) match {
+          case Some(seq) => seq += al.toAttribute
+          case None =>
+            val temp: mutable.Buffer[Expression] = mutable.ArrayBuffer(al.child, al.toAttribute)
+            groupHeadToGroupMap += al.child -> temp
+        }
+      case _ =>  // not expected
+    })
+
+
+    // Find those incoming attributes which are not projecting out
+    val attribsRemoved = inputAttribs.filterNot(attr =>
+        outputAttribs.exists(_.canonicalized == attr.canonicalized)).toSet
+    // for each of the attribute getting removed , find replacement if any
+    val replaceableAttributeMap: ExpressionMap[Attribute] = new ExpressionMap[Attribute]()
+    fillReplacementOrClearGroupHeadForRemovedAttributes(attribsRemoved, replaceableAttributeMap,
+      groupHeadToGroupMap)
+    val (attribBasedEquivalenceList, initialExprBasedEquivalenceList) = {
+      val tup = groupHeadToGroupMap.values.partition(buff =>
+        buff.head match {
+          case _: Attribute => true
+          case _ => false
+        }
+      )
+      (tup._1.to[mutable.Buffer], tup._2.to[mutable.Buffer])
+    }
+
+    // now work on expression (other than attribute based)
+    val replaceableExpressionMap: ExpressionMap[Attribute] = new ExpressionMap[Attribute]()
+    val exprBasedEquivalenceList = getUpdatedExpressionEquivalenceListWithSideEffects(
+        attribsRemoved, replaceableAttributeMap, replaceableExpressionMap,
+        attribBasedEquivalenceList, initialExprBasedEquivalenceList)
+
+    // Now update or remove the filters depending upon which
+    // can survive based on replacement available
+    val updatedFilterExprs = getUpdatedConstraints(attribsRemoved, replaceableAttributeMap,
+      replaceableExpressionMap)
+
+    exprBasedEquivalenceList.foreach(buffer => {
+      val expr = buffer.head
+      if (!existingAttribGroupHead.exists(_.canonicalized == expr.canonicalized)) {
+        val newConstraints = expr match {
+          case _: Literal => buffer.drop(1).map(x => EqualNullSafe(x, expr))
+          case _ => Seq(EqualNullSafe(expr, buffer(1)))
+        }
+        newConstraints.foreach(newConstraint =>
+        if (!updatedFilterExprs.exists(_.canonicalized == newConstraint.canonicalized)) {
+          updatedFilterExprs += newConstraint
+        })
+      }
+    })
+
+    // remove all mapping sof constants as the expression
+     val newExprBasedEquivalenceList = exprBasedEquivalenceList.filter(_.head.references.nonEmpty)
+
+    // Now filter the attribBasedEquivalenceList which only has 1 element
+    // This is because if there is only 1 element in the buffer, it cannot
+    // be of any help in making a constraint survive, in case that attribute
+    // is not part of output set, so no point in keeping it in the attribute
+    // equivalence list.
+    val newAttribBasedEquivalenceList = attribBasedEquivalenceList.filter(_.size > 1)
+
+    // generate 1 new nullsafe equality constraint based on equivalence list
+    newAttribBasedEquivalenceList.foreach(buffer => {
+      assert(buffer.size > 1)
+      if (!existingAttribGroupHead.exists(_.canonicalized == buffer.head)) {
+        val newConstraint = EqualNullSafe(buffer.head, buffer(1))
+        if (!updatedFilterExprs.exists(_.canonicalized == newConstraint.canonicalized)) {
+          updatedFilterExprs += newConstraint
+        }
+      }
+    })
+    val canonicalized = updatedFilterExprs.map(_.canonicalized).to[mutable.Set]
+
+    assert(canonicalized.size == updatedFilterExprs.size)
+    new ConstraintSet(canonicalized, updatedFilterExprs, newAttribBasedEquivalenceList,
+      newExprBasedEquivalenceList)
+  }
+
+  private def getUpdatedExpressionEquivalenceListWithSideEffects(attribsRemoved: Set[Attribute],
+    replaceableAttributeMap: ExpressionMap[Attribute],
+    replaceableExpressionMap: ExpressionMap[Attribute],
+    attribBasedEquivalenceList: mutable.Buffer[mutable.Buffer[Expression]],
+    initialExprBasedEquivalenceList: mutable.Buffer[mutable.Buffer[Expression]]
+  ): mutable.Buffer[mutable.Buffer[Expression]] = {
+    initialExprBasedEquivalenceList.map(buff => {
+        val zerothElem = buff.head
+        val refs = zerothElem.references
+        if (refs.nonEmpty) {
+          if (refs.exists(ref => attribsRemoved.exists(_.canonicalized == ref.canonicalized))) {
+            val newZeroth = zerothElem.transformUp {
+              case attr: Attribute =>
+                if (attribsRemoved.exists( _.canonicalized == attr.canonicalized)) {
+                  replaceableAttributeMap.get(attr) match {
+                    case Some(x) => x
+                    case None => attr
+                  }
+                } else attr
+            }
+            if (newZeroth.references.exists(ref =>
+              attribsRemoved.exists(_.canonicalized == ref.canonicalized))) {
+              val removedExpression = buff.remove(0)
+              if (buff.nonEmpty) {
+                replaceableExpressionMap += (removedExpression -> buff.head
+                  .asInstanceOf[Attribute])
+              }
+              // If the buffer size after removal is > 1
+              // transfer the remaining attributes in the buffer to attrib equivalent list
+              // If the buffer size == 1, then it will be removed in the final filtration
+              // as the buffer size == 1 implies that the 0th position expression cannot
+              // survive up the chain, if any of the attribute it is referencing is lost,
+              // as there is no alias to support it
+              if (buff.size > 1) {
+                assert(buff.forall {
+                  case _: Attribute => true
+                  case _ => false
+                })
+                attribBasedEquivalenceList += buff
+                mutable.Buffer.empty[Expression]
+              } else {
+                buff
+              }
+            } else {
+              buff(0) = newZeroth
+              buff
+            }
+          } else {
+            buff
+          }
+        } else {
+          attribsRemoved.foreach(ConstraintSet.removeCanonicalizedAttribute(buff, _))
+          buff
+        }
+      }).filter(_.size > 1)
+    // The above filtering ensures that if the buffer size after removal is 1,
+    // then purge the buffer
+  }
+
+  private def getUpdatedConstraints(attribsRemoved: Set[Attribute],
+    replaceableAttributeMap: ExpressionMap[Attribute],
+    replaceableExpressionMap: ExpressionMap[Attribute]): mutable.Buffer[Expression] = {
+    this.originals.flatMap(filterExpr => {
+      val attribRefs = filterExpr.references
+      if (attribRefs.isEmpty) {
+        Set.empty[Expression]
+      } else {
+        if (attribRefs.exists(ref => attribsRemoved.exists(_.canonicalized == ref.canonicalized))) {
+          val newFilterExp = filterExpr.transformUp {
+            case attr: Attribute =>
+              if (attribsRemoved.exists(_.canonicalized == attr.canonicalized)) {
+                replaceableAttributeMap.get(attr) match {
+                  case Some(x) => x
+                  case None => attr
+                }
+              } else attr
+          }
+          // if filter still contains attribs which will be removed,
+          // below code checks if filter can survive by replacement with a complex expression
+          if (newFilterExp.references.exists(ref =>
+            attribsRemoved.exists(_.canonicalized == ref.canonicalized))) {
+            val newNewFilterExp = newFilterExp.transformUp {
+              case expr: Expression =>
+                replaceableExpressionMap.get(expr) match {
+                  case Some(x) => x
+                  case None => expr
+                }
+            }
+            if (newNewFilterExp.references.exists(ref =>
+                attribsRemoved.exists(_.canonicalized == ref.canonicalized))) {
+              Set.empty[Expression]
+            } else {
+              Set(newNewFilterExp).filterNot(x =>
+                this.originals.exists(_.canonicalized == x.canonicalized))
+            }
+          } else {
+            Set(newFilterExp).filterNot(x =>
+              this.originals.exists(_.canonicalized == x.canonicalized))
+          }
+        } else {
+          Set(filterExpr)
+        }
+      }
+    })
+  }
+
+  private def fillReplacementOrClearGroupHeadForRemovedAttributes(attribsRemoved: Set[Attribute],
+    replaceableAttributeMap: ExpressionMap[Attribute],
+    groupHeadToGroupMap: ExpressionMap[mutable.Buffer[Expression]]): Unit = {
+    attribsRemoved.foreach(attrib => {
+      groupHeadToGroupMap.get(attrib) match {
+        case Some(buff) =>
+          val exprRemoved = buff.remove(0)
+          assert(attrib.exprId == exprRemoved.asInstanceOf[Attribute].exprId)
+          // remove any attributes which may be in position other than 0 in the buffer
+          attribsRemoved.foreach(x => ConstraintSet.removeCanonicalizedAttribute(buff, x))
+          if (buff.nonEmpty) {
+            replaceableAttributeMap += attrib -> buff.head.asInstanceOf[Attribute]
+          } else {
+            // purge the buffer if there is no replacement and the attribute being removed
+            // was the only one present
+            groupHeadToGroupMap.remove(exprRemoved)
+          }
+        case None => // there may be attributes which are removed but lying in
+          // position other than 0th
+          // which may be such that zeroth attrib is not present in the list of attrib being
+          // removed & hence escaped in above op. so we need to again filter the map
+          // at this point it is guaranteed that once the filtering has happened , there will
+          // be no buffer which can be empty
+          groupHeadToGroupMap.values.foreach(buff => {
+            ConstraintSet.removeCanonicalizedAttribute(buff, attrib)
+            assert(buff.nonEmpty)
+          })
+      }
+    })
+  }
+
+  override def withNewConstraints(filters: Set[Expression]): ConstraintSet = {
+    new ConstraintSet(filters.map(_.canonicalized).to[mutable.Set], filters.to[mutable.Buffer],
+      this.attribRefBasedEquivalenceList.map(_.clone()),
+      this.expressionBasedEquivalenceList.map(_.clone))
+  }
+
+  override def attributesRewrite(mapping: AttributeMap[Attribute]): ConstraintSet = {
+    val transformer: PartialFunction[Expression, Expression] = {
+      case a: Attribute => mapping(a)
+    }
+    val newOriginals = this.originals.map(x => x.transformUp(transformer))
+    val newAttribBasedEquiList = this.attribRefBasedEquivalenceList.map(buff =>
+      buff.map(x => x.transformUp(transformer)))
+    val newExpBasedEquiList = this.expressionBasedEquivalenceList.map(buff =>
+      buff.map(x => x.transformUp(transformer)))
+    new ConstraintSet(newOriginals.map(_.canonicalized).to[mutable.Set], newOriginals,
+      newAttribBasedEquiList, newExpBasedEquiList)
+  }
+
+  /**
+   * The constraintset contains the bare minimum non redundant conditions.
+   * The expand method creates other redundant combinations of constraint
+   * conditions so that filters for push down through join etc can be created
+   * This function guarantees that there will be at least one condition created from a
+   * given non redundant constraint in the constraintset, such that each of the alias
+   * of the base attribute found in the non redundant constraint, included.
+   * for eg, lets say the non redundant constraint contained is
+   * a + b + c > 10.
+   * and the aliases are:
+   * for a -> a1, a2
+   * for b -> b1
+   * for c -> c1, c2, c3
+   * Then the expand function will return following constraints
+   * a + b + c > 10, a1 + b + c > 10, a2 + b + c > 10, a + b1 + c > 10,
+   * a + b + c1 > 10, a + b + c2 > 10, a + b + c3 > 10
+   * P.S: due to a trivial bug( or behaviour in the logic of code below)
+   * it is possible that in case of a simple  equalNullsafe condition of the form
+   * a = a1  which is present in the constraintset as a non redundant condition
+   * and if aliases are a -> a1, a2
+   * the expanded form returned will be  a <=> a1 && a2 <=> a1. ( instead of ideal condition
+   * a <=> a2). But this does not effect the overall logic of code as far as the behaviour
+   * of expand function is concerned. as it is returning a condition inovlving each of the
+   * attribute. Will try to make it behave ideally later.
+   *
+   * @return A set containing all the non redundant conditions in the constraintset +
+   *         all other rdundant form of constraints which gurantee that each alias for
+   *         the base attribute in the non redundant constraint, is represented at least once.
+   */
+  override def expand: Set[Expression] = {
+    def createConstraintsFromAttribEquivalence(): Seq[Expression] = {
+      // find all attribs ref in all base expressions
+
+      val baseAttribs = this.originals.flatMap(_.references)
+      // collect all the list of substitutables for these base attribs
+      val substitutables = baseAttribs
+        .map(x => x -> this.attribRefBasedEquivalenceList.filter(_.head == x)).filter(_._2.nonEmpty)
+        .toMap
+      this.originals.flatMap(expr => {
+        val attribRefs = expr.references
+        val commonRefs = substitutables.keySet.intersect(attribRefs.toSet)
+        if (commonRefs.nonEmpty) {
+          commonRefs.flatMap(attr => {
+            substitutables(attr).flatMap(subst => subst.drop(1).map(substWith => {
+                  val newConstraint = expr.transformUp {
+                    case att: Attribute if att.canonicalized == attr.canonicalized &&
+                        !attribRefs.contains(substWith.asInstanceOf[Attribute]) =>
+                      substWith.asInstanceOf[Attribute]
+                  }
+                  newConstraint match {
+                    case x: EqualNullSafe => if (this.originals.exists(x => x.canonicalized ==
+                      newConstraint.canonicalized)) {
+                        null
+                      } else {
+                        x
+                      }
+                    case _ => newConstraint
+                  }
+                }).filterNot(_ == null)
+            )
+          })
+        } else {
+          Set.empty[Expression]
+        }
+      })
+    }
+
+    def createConstraintFromExprEquivalence(): Seq[Expression] = {
+      // find all attribs ref in all base expressions
+      val baseAttribsSet = this.originals.map(_.references)
+      // filter out the equivalence expressions of interest
+      val exprsOfInterest = this.expressionBasedEquivalenceList.filter(buff =>
+        baseAttribsSet.exists(y => buff.head.references.subsetOf(y))
+      )
+      this.originals.zip(baseAttribsSet).flatMap {
+        case (cond, attribSet) =>
+          exprsOfInterest.flatMap(buffer => {
+            if (buffer.head.references.subsetOf(attribSet) &&
+                cond.find(_.canonicalized == buffer.head.canonicalized).isDefined) {
+              buffer.drop(1).filterNot(e => attribSet.contains(e.asInstanceOf[NamedExpression])).
+                map(x => cond.transformUp {
+                    case y: Expression
+                      if y.canonicalized == buffer.head.canonicalized => x
+                  }).filterNot(e => this.originals.exists(_.canonicalized == e.canonicalized))
+            } else {
+              Seq.empty[Expression]
+            }
+          })
+      }
+    }
+    val newOriginals = createConstraintsFromAttribEquivalence() ++
+      createConstraintFromExprEquivalence() ++ this.originals
+    ExpressionSet(newOriginals)
+  }
+
+  /**
+   * This function is used during pruning and also when any new condition is being
+   * added to the constraintset. The idea is that existing conditions in the constraintset
+   * are the bare minimum essential (non redundant) constraints. So any filter to be checked
+   * if it can be pruned or not can be checked using this function, if that filter is
+   * derivable using the constraints available. If it is derivable it means the filter is
+   * redundant and can be pruned. Also if any new constraint is being added to the
+   * constraintset that also can be checked if it is redundant or not. If redundant,
+   * it will not get added. This method converts the incoming expression into its
+   * constituents attributes before being checked.
+   * For. eg if the incoming expression is say z + c > 10, where z is an alias of base
+   * attributes a + b. And say constraintset already contains a condition
+   * a + b + c > 10. Then z + c > 10, is converted into a + b + c > 10 making use
+   * of tacking data of aliases, and it will be found in the constraintset &
+   * contains will return as true
+   * @param elem Expression to be checked if it is redundant or not.
+   * @return boolean true if it already exists in constraintset( is redundant)
+   */
+  override def contains(elem: Expression): Boolean = {
+    if (super.contains(elem)) {
+      true
+    } else {
+      // check canonicalized
+      // find all attribs ref in all base expressions
+      val baseAttribs = elem.references
+      // collect all the list of canonicalized attributes for these base attribs
+      val substitutables = baseAttribs
+        .map(x => {
+          val seqContainingAttrib = this.attribRefBasedEquivalenceList
+            .filter(buff => buff.exists(_.canonicalized == x.canonicalized))
+          assert(seqContainingAttrib.isEmpty || seqContainingAttrib.size == 1)
+          if (seqContainingAttrib.nonEmpty) {
+            x -> seqContainingAttrib.head.head
+          } else {
+            x -> null
+          }
+        })
+        .filter(_._2 ne null)
+        .toMap
+      val canonicalizedExp = elem.transformUp {
+        case att: Attribute => substitutables.getOrElse(att, att)
+      }
+
+      if (super.contains(canonicalizedExp)) {
+        true
+      } else {
+        val newCanonicalized = canonicalizedExp.transformUp {
+          case expr =>
+            this.expressionBasedEquivalenceList
+              .find(buff => buff.exists(_.canonicalized == expr.canonicalized))
+              .map(_.head)
+              .getOrElse(expr)
+        }
+        super.contains(newCanonicalized)
+      }
+    }
+  }
+
+  /**
+   * This gives all the constraints whose references are subset of canonicalized
+   * attributes of interests and the number of references are > 1.
+   * Eventually this function should be augmented to return all the
+   * conditions for join push down & not just of compound types. This will
+   * eliminate the need of expand function which is still extravagant
+   * @param attribsOfInterest A sequence of attributes for which constraints are desired &
+   *                          constraints should be such that its references are subset of
+   *                          the canonicalized version of attributes in the passed sequence
+   * @return Sequence of constraint expressions of compound types.
+   */
+  override def getConstraintsSubsetOfAttributes(attribsOfInterest: Seq[Attribute]): Seq[Expression]
+  = {
+    val canonicalAttribsMapping = attribsOfInterest.map(att => this.attribRefBasedEquivalenceList.
+      find(buff => buff.exists(_.canonicalized == att.canonicalized)).map(buff =>
+      buff.head.asInstanceOf[Attribute] -> att).getOrElse(att -> att)).toMap
+    this.originals.collect {
+        case expr if expr.references.toSet.subsetOf(canonicalAttribsMapping.keySet) &
+            expr.references.size > 1 && expr.deterministic => expr
+      }.map(expr => expr.transformUp {
+          case attr: Attribute => canonicalAttribsMapping(attr)
+        })
+  }
+
+  /**
+   * Consider a new filter generated out of constraints of the form
+   * IsNotNull(case....a....b...c) where the case expressions are
+   * complex. Since new filters generated out of constraints are always canonicalized
+   * it is possible that they are not compact as they are written in terms of
+   * basic attributes. If an alias to this complex expression is present, then it
+   * makes sense to rewrite the newly generated filter as IsNotNull(alias.attribute)
+   * to avoid expensive calculation, especially that we have large case optimization.
+   * This function simply tries to compact the expression where possible by replacing
+   * the expression with an alias's attribute.
+   *
+   * @param expr Expression to compact ( decanonicalize)
+   * @return Expression which is compacted, if possible
+   */
+  override def rewriteUsingAlias(expr: Expression): Expression =
+    expr.transformDown {
+      case x: Attribute => x
+      case x => getDecanonicalizedAttributeForExpression(x)
+    }
+
+  /**
+   * Decanonicalizes the NullIntolerant Expression.
+   * The need for this arises, because when spark is attempting to generate
+   * new NotNull constraints from the existing constraint, it may not return
+   * any NotNull constraints, if the underlying subexpression is not of type
+   * NullIntolerant.
+   * Consider following two cases:
+   * Lets say the base  canonicalized constraint is of the form a + b > 5.
+   * A GreaterThan expression is NullIntolerant, so spark delves deep
+   * and finds, it is composed of a & b attributes, & thus returns two
+   * new IsNotNull constraints, namely IsNotNull(a) and IsNotNull(b).
+   * But if the base canonicalized constraint is of the form
+   * case(a....., b...) > 5, in this situation because case expression
+   * does not implement NullIntolerant, spark does not go deep & hence
+   * returns 0 not null constraints.
+   * This function handles this situation, by replacing an underlying
+   * canonicalized complex expression with an alias's attribute so
+   * that NotNull constraint can be generated.
+   * Thus case (a.....b) > 5 will be temporarily converted into z > 5.
+   * Once an IsNotNull(z) is returned as a new constraint, we store
+   * IsNotNull(z) in the Constraint set, again as canonicalized constraint,
+   * that is IsNotNull(case...a...b), which will ensure that pruning logic
+   * works fine.
+   *
+   * @return Set of constraint expressions where underlying NullIntolerant
+   *         Expressions have been decanonicalized.
+   */
+  override def getConstraintsWithDecanonicalizedNullIntolerant: Set[Expression] = {
+    def decanonicalizeNotNullIntolerant(expr: Expression): Expression = {
+      var foundNotNullIntolerant = false
+      expr.transformUp {
+        case x: LeafExpression => x
+        case x: NullIntolerant => if (foundNotNullIntolerant) {
+          val y = getDecanonicalizedAttributeForExpression(x)
+          if (y ne x) {
+            foundNotNullIntolerant = false
+          }
+          y
+        } else {
+          x
+        }
+        case x => val y = getDecanonicalizedAttributeForExpression(x)
+          if (y ne x) {
+            foundNotNullIntolerant = false
+          } else {
+            foundNotNullIntolerant = true
+          }
+          y
+      }
+    }
+
+    this.originals.map(expr => expr match {
+      case _: NullIntolerant => decanonicalizeNotNullIntolerant(expr)
+      case _ => expr
+    }).toSet
+  }
+
+  private def getDecanonicalizedAttributeForExpression(expr: Expression): Expression = {
+    val canonicalizedExpr = convertToCanonicalizedIfRequired(expr)
+    val bufferIndex = this.expressionBasedEquivalenceList.indexWhere(_.head == canonicalizedExpr)
+    if (bufferIndex != -1) {
+      // buffer size will always be > 1
+      this.expressionBasedEquivalenceList(bufferIndex).last
+    } else {
+      expr
+    }
+  }
+}
+
+object ConstraintSet {
+  def removeCanonicalizedAttribute(
+    buff: mutable.Buffer[Expression],
+    attr: Attribute
+  ): Unit = {
+    var keepGoing = true
+    while (keepGoing) {
+      val indx = buff.indexWhere(_.canonicalized == attr.canonicalized)
+      if (indx == -1) {
+        keepGoing = false
+      } else {
+        buff.remove(indx)
+      }
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpressionMap.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+import scala.collection.mutable
+
+object ExpressionMap {
+  /** Constructs a new [[ExpressionMap]] by applying [[Canonicalize]] to `expressions`. */
+  def apply[T](map: mutable.Map[Expression, T]): ExpressionMap[T] = {
+    val newMap = new ExpressionMap[T](map)
+    map.foreach(newMap.add)
+    newMap
+  }
+}
+
+/**
+ * A helper class created on the lines of [[AttributeMap]] and [[ExpressionSet]]
+ * The key added in the Map is always stored in canonicalized form.
+ *
+ * @param baseMap The underlying Map object which is either empty or pre-populated with all the
+ *                keys being canonicalized form of expressions
+ * @tparam T The value part of the Map
+ */
+class ExpressionMap[T](val baseMap: mutable.Map[Expression, T] = new mutable.HashMap[Expression, T])
+  extends mutable.Map[Expression, T] {
+
+  override def get(expr: Expression): Option[T] =
+    baseMap.get(expr.canonicalized)
+
+
+  protected def add(tup: (Expression, T)): Unit = {
+
+    this.baseMap += (tup._1.canonicalized -> tup._2)
+
+  }
+
+  override def contains(expr: Expression): Boolean =
+    baseMap.contains(expr.canonicalized)
+
+  override def +=(kv: (Expression, T)): this.type = {
+    this.add(kv)
+    this
+  }
+
+  override def iterator: Iterator[(Expression, T)] = baseMap.iterator
+
+  override def -=(key: Expression): this.type = {
+    this.baseMap -= key.canonicalized
+    this
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -568,6 +568,8 @@ abstract class BinaryComparison extends BinaryOperator with Predicate {
   }
 
   protected lazy val ordering: Ordering[Any] = TypeUtils.getInterpretedOrdering(left.dataType)
+
+  def reverseOperands(): BinaryComparison
 }
 
 
@@ -623,6 +625,7 @@ case class EqualTo(left: Expression, right: Expression)
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     defineCodeGen(ctx, ev, (c1, c2) => ctx.genEqual(left.dataType, c1, c2))
   }
+  def reverseOperands(): BinaryComparison = this
 }
 
 // TODO: although map type is not orderable, technically map type should be able to be used
@@ -682,6 +685,7 @@ case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComp
         boolean ${ev.value} = (${eval1.isNull} && ${eval2.isNull}) ||
            (!${eval1.isNull} && !${eval2.isNull} && $equalCode);""", isNull = FalseLiteral)
   }
+  def reverseOperands(): BinaryComparison = this
 }
 
 @ExpressionDescription(
@@ -712,6 +716,7 @@ case class LessThan(left: Expression, right: Expression)
   override def symbol: String = "<"
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = ordering.lt(input1, input2)
+  def reverseOperands(): BinaryComparison = GreaterThan(right, left)
 }
 
 @ExpressionDescription(
@@ -742,6 +747,7 @@ case class LessThanOrEqual(left: Expression, right: Expression)
   override def symbol: String = "<="
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = ordering.lteq(input1, input2)
+  def reverseOperands(): BinaryComparison = GreaterThanOrEqual(right, left)
 }
 
 @ExpressionDescription(
@@ -772,6 +778,8 @@ case class GreaterThan(left: Expression, right: Expression)
   override def symbol: String = ">"
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = ordering.gt(input1, input2)
+
+  def reverseOperands(): BinaryComparison = LessThan(right, left)
 }
 
 @ExpressionDescription(
@@ -802,4 +810,5 @@ case class GreaterThanOrEqual(left: Expression, right: Expression)
   override def symbol: String = ">="
 
   protected override def nullSafeEval(input1: Any, input2: Any): Any = ordering.gteq(input1, input2)
+  def reverseOperands(): BinaryComparison = LessThanOrEqual(right, left)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -153,7 +153,8 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
   }
 
   private def buildNewJoinType(filter: Filter, join: Join): JoinType = {
-    val conditions = splitConjunctivePredicates(filter.condition) ++ filter.constraints
+    val conditions = splitConjunctivePredicates(filter.condition).
+      map(filter.constraints.convertToCanonicalizedIfRequired) ++ filter.constraints
     val leftConditions = conditions.filter(_.references.subsetOf(join.left.outputSet))
     val rightConditions = conditions.filter(_.references.subsetOf(join.right.outputSet))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
 
@@ -173,7 +174,13 @@ abstract class UnaryNode extends LogicalPlan {
     allConstraints -- child.constraints
   }
 
-  override protected def validConstraints: Set[Expression] = child.constraints
+  override protected def validConstraints: ExpressionSet =
+    if (!this.inputSet.subsetOf(this.outputSet)) {
+      child.constraints.updateConstraints(this.output,
+        child.output, Seq.empty[NamedExpression], None)
+    } else {
+      child.constraints
+    }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -179,6 +179,13 @@ object SQLConf {
       .intConf
       .createWithDefault(10)
 
+  val OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION =
+    buildConf("spark.sql.optimizer.optimizedConstraintPropagation.enabled")
+      .internal()
+      .doc("use optimized algorithm for constraint propagation")
+      .booleanConf
+      .createWithDefault(true)
+
   val COMPRESS_CACHED = buildConf("spark.sql.inMemoryColumnarStorage.compressed")
     .doc("When set to true Spark SQL will automatically select a compression codec for each " +
       "column based on statistics of the data.")
@@ -1729,6 +1736,8 @@ class SQLConf extends Serializable with Logging {
   def gatherFastStats: Boolean = getConf(GATHER_FASTSTAT)
 
   def optimizerMetadataOnly: Boolean = getConf(OPTIMIZER_METADATA_ONLY)
+
+  def useOptimizedConstraintPropagation: Boolean = getConf(OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION)
 
   def wholeStageEnabled: Boolean = getConf(WHOLESTAGE_CODEGEN_ENABLED)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -19,6 +19,10 @@ package org.apache.spark.sql.catalyst.plans
 
 import java.util.TimeZone
 
+import scala.collection.mutable
+
+import org.scalatest.Ignore
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -28,15 +32,23 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, DoubleType, IntegerType, LongType, StringType}
 
+
+/**
+ * This class is extended by OptimizedConstraintSuite and when it runs,  all the tests
+ * of this class also be executed. The ignore is to prevent the tests from running twice
+ * unnecessarily
+ */
+
+@Ignore
 class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
 
-  private def resolveColumn(tr: LocalRelation, columnName: String): Expression =
+  def resolveColumn(tr: LocalRelation, columnName: String): Expression =
     resolveColumn(tr.analyze, columnName)
 
-  private def resolveColumn(plan: LogicalPlan, columnName: String): Expression =
+  def resolveColumn(plan: LogicalPlan, columnName: String): Expression =
     plan.resolveQuoted(columnName, caseInsensitiveResolution).get
 
-  private def verifyConstraints(found: ExpressionSet, expected: ExpressionSet): Unit = {
+  def verifyConstraints(found: ExpressionSet, expected: ExpressionSet): Unit = {
     val missing = expected -- found
     val extra = found -- expected
     if (missing.nonEmpty || extra.nonEmpty) {
@@ -130,8 +142,7 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
     assert(tr.where('c.attr > 10).select('a.as('x), 'b.as('y)).analyze.constraints.isEmpty)
 
     val aliasedRelation = tr.where('a.attr > 10).select('a.as('x), 'b, 'b.as('y), 'a.as('z))
-
-    verifyConstraints(aliasedRelation.analyze.constraints,
+    verifyConstraints(ExpressionSet(aliasedRelation.analyze.constraints.expand),
       ExpressionSet(Seq(resolveColumn(aliasedRelation.analyze, "x") > 10,
         IsNotNull(resolveColumn(aliasedRelation.analyze, "x")),
         resolveColumn(aliasedRelation.analyze, "b") <=> resolveColumn(aliasedRelation.analyze, "y"),
@@ -171,14 +182,19 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
       .where('a.attr > 10)
       .union(tr2.where('d.attr > 11))
       .analyze.constraints,
-      ExpressionSet(Seq(a > 10 || a > 11, IsNotNull(a))))
+      new ConstraintSet(mutable.Buffer((a > 10 || a > 11), IsNotNull(a))))
 
     val b = resolveColumn(tr1, "b")
+
+    val cond1 = a > 10 || a > 11
+    val cond2 = b < 10 || b < 11
+
     verifyConstraints(tr1
       .where('a.attr > 10 && 'b.attr < 10)
       .union(tr2.where('d.attr > 11 && 'e.attr < 11))
       .analyze.constraints,
-      ExpressionSet(Seq(a > 10 || a > 11, b < 10 || b < 11, IsNotNull(a), IsNotNull(b))))
+      new ConstraintSet(mutable.Buffer(cond1, cond2,
+        IsNotNull(a), IsNotNull(b))))
   }
 
   test("propagating constraints in intersect") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/OptimizedConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/OptimizedConstraintPropagationSuite.scala
@@ -1,0 +1,1151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans
+
+import org.junit.Assert._
+
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliases, EmptyFunctionRegistry}
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{IsNotNull, _}
+import org.apache.spark.sql.catalyst.optimizer.{CombineFilters, CombineUnions,
+  InferFiltersFromConstraints, Optimizer, PruneFilters, PushDownPredicate,
+  PushPredicateThroughJoin, PushProjectionThroughUnion}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, LongType}
+
+class OptimizedConstraintPropagationSuite extends ConstraintPropagationSuite {
+
+  /**
+   * Default spark optimizer is not used in the tests as some of the tests were false passing.
+   * Many assertions go through fine hiding the bugs because of other rules in the optimizer.
+   * For eg., a test dedicated to test filter pruning ( involving aliases) & hence relying
+   * on contains function of ConstraintSet ( & indirectly the attributeEquivalenceList etc )
+   * was false passing because of an optimizer rule, which replaces the alias with the actual
+   * expression in the plan. Combining Filter is commented just to be sure that ConstraintSet
+   * coming out of each node contains right the constraints & more importantly the
+   * attributeEquivalenceList & expressionEquivalenceList contains the right data.
+   * Otherwise it is possible that those Lists are empty & tests false passing
+   */
+
+  test("checking number of base constraints & expanded in project node") {
+    assume(SQLConf.get.useOptimizedConstraintPropagation)
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    val y = tr.where('c.attr > 10).select('a.as('x), 'b.as('y), 'c, 'c.as('c1)).analyze
+    assert(y.resolved)
+    val constraints = y.constraints
+    assertEquals(3, constraints.size)
+    assertEquals(5, constraints.expand.size)
+    verifyConstraints(ExpressionSet(constraints.expand),
+      ExpressionSet(Seq(resolveColumn(y.analyze, "c") > 10,
+        resolveColumn(y.analyze, "c1") > 10,
+        IsNotNull(resolveColumn(y.analyze, "c")),
+        IsNotNull(resolveColumn(y.analyze, "c1")),
+        EqualNullSafe(resolveColumn(y.analyze, "c"),
+          resolveColumn(y.analyze, "c1")))))
+  }
+
+  test("checking number of base constraints & expanded with " +
+    "filter dependent on multiple attributes") {
+    assume(SQLConf.get.useOptimizedConstraintPropagation)
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    val y = tr.where('c.attr + 'a.attr > 10).select('a, 'a.as('x), 'b.as('y), 'c,
+      'c.as('c1)).analyze
+    assert(y.resolved)
+    val constraints = y.constraints
+    assertEquals(5, constraints.size)
+    assertEquals(9, constraints.expand.size)
+    verifyConstraints(ExpressionSet(constraints.expand),
+      ExpressionSet(Seq(
+        resolveColumn(y.analyze, "c") +
+          resolveColumn(y.analyze, "a") > 10,
+        resolveColumn(y.analyze, "c") +
+          resolveColumn(y.analyze, "x") > 10,
+        resolveColumn(y.analyze, "c1") +
+          resolveColumn(y.analyze, "a") > 10,
+
+        IsNotNull(resolveColumn(y.analyze, "c")),
+        IsNotNull(resolveColumn(y.analyze, "a")),
+        IsNotNull(resolveColumn(y.analyze, "x")),
+        IsNotNull(resolveColumn(y.analyze, "c1")),
+
+        EqualNullSafe(resolveColumn(y.analyze, "c"),
+          resolveColumn(y.analyze, "c1")),
+        EqualNullSafe(resolveColumn(y.analyze, "a"),
+          resolveColumn(y.analyze, "x")))))
+  }
+
+  test("checking filter pruning") {
+    assume(SQLConf.get.useOptimizedConstraintPropagation)
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    val y = tr.where('c.attr + 'a.attr > 10).select('a, 'a.as('x), 'b.as('y), 'c,
+      'c.as('c1)).where('x.attr + 'c1.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    val constraints = optimized.constraints
+    assertEquals(5, constraints.size)
+    assertEquals(9, constraints.expand.size)
+    verifyConstraints(ExpressionSet(constraints.expand),
+      ExpressionSet(Seq(
+        resolveColumn(y.analyze, "c") +
+          resolveColumn(y.analyze, "a") > 10,
+        resolveColumn(y.analyze, "c") +
+          resolveColumn(y.analyze, "x") > 10,
+        resolveColumn(y.analyze, "c1") +
+          resolveColumn(y.analyze, "a") > 10,
+
+        IsNotNull(resolveColumn(y.analyze, "c")),
+        IsNotNull(resolveColumn(y.analyze, "a")),
+        IsNotNull(resolveColumn(y.analyze, "x")),
+        IsNotNull(resolveColumn(y.analyze, "c1")),
+
+        EqualNullSafe(resolveColumn(y.analyze, "c"),
+          resolveColumn(y.analyze, "c1")),
+        EqualNullSafe(resolveColumn(y.analyze, "a"),
+          resolveColumn(y.analyze, "x")))))
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assertEquals(1, allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assertEquals(1, conditionalExps.size)
+    val correctAnswer = tr.where('c.attr + 'a.attr > 10 && IsNotNull('a) && IsNotNull('c)).
+      select('a, 'a.as('x), 'b.as('y), 'c, 'c.as('c1)).analyze
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning on Join Node") {
+    val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+    val tr2 = LocalRelation('x.int, 'y.string, 'z.int)
+    val y = tr1.where('c.attr + 'a.attr > 10).select('a, 'a.as('a1), 'a.as('a2),
+      'b.as('b1), 'c,
+      'c.as('c1)).join(tr2, Inner, Some("a2".attr === "x".attr))
+      .where('a1.attr + 'c1.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+
+    val conditionalExps = allFilters.flatMap(filter =>
+      filter.expressions.flatMap(expr => expr.collect {
+        case x: GreaterThan => x
+        case y: LessThan => y
+      }))
+    assertEquals(1, conditionalExps.size)
+    val correctAnswer = tr1.where('c.attr + 'a.attr > 10 && IsNotNull('a) && IsNotNull('c)).
+      select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c,
+        'c.as('c1)).join(tr2.where(IsNotNull('x)), Inner, Some("a2".attr === "x".attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("new filter pushed down on Join Node") {
+    val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+    val tr2 = LocalRelation('x.int, 'y.string, 'z.int)
+    val y = tr1.where('c.attr + 'a.attr > 10 && 'a.attr > -15).select('a, 'a.as('a1), 'a.as('a2),
+      'b.as('b1), 'c,
+      'c.as('c1)).join(tr2, Inner, Some("a2".attr === "x".attr))
+      .where('a1.attr + 'c1.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    val conditionalExps = allFilters.flatMap(filter =>
+      filter.expressions.flatMap(expr => expr.collect {
+        case x: GreaterThan => x
+        case y: LessThan => y
+      }))
+    assertEquals(3, conditionalExps.size)
+    val correctAnswer = tr1.where('c.attr + 'a.attr > 10 && 'a.attr > -15
+      && IsNotNull('a) && IsNotNull('c)).select('a, 'a.as('a1), 'a.as('a2),
+      'b.as('b1), 'c,
+      'c.as('c1)).join(tr2.where(IsNotNull('x) && 'x.attr > -15),
+      Inner, Some("a2".attr === "x".attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("new filter pushed down on Join Node with multiple join conditions") {
+    assume(SQLConf.get.useOptimizedConstraintPropagation)
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+      val tr2 = LocalRelation('x.int, 'y.string, 'z.int)
+      tr1.where('c.attr + 'a.attr > 10 && 'a.attr > -15).select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c,
+        'c.as('c1)).join(tr2, Inner, Some("a2".attr === "x".attr && 'c1.attr === 'z.attr))
+        .where('a1.attr + 'c1.attr > 10)
+    }
+    val (optimized, _) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    val conditionalExps = allFilters.flatMap(filter =>
+      filter.expressions.flatMap(expr => expr.collect {
+        case x: GreaterThan => x
+        case y: LessThan => y
+      }))
+    assertEquals(4, conditionalExps.size)
+
+    // there should be a + operator present on each side of the join node
+    val joinNode = optimized.collectFirst {
+      case j: Join => j
+    }.get
+    assertTrue(joinNode.left.collect {
+      case f: Filter => f
+    }.exists(f => f.condition.collectFirst {
+      case a: Add => a
+    }.isDefined))
+    assertTrue(joinNode.right.collect {
+      case f: Filter => f
+    }.exists(f => f.condition.collectFirst {
+      case a: Add => a
+    }.isDefined))
+    val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+    val tr2 = LocalRelation('x.int, 'y.string, 'z.int)
+    val correctAnswer = tr1.where('c.attr + 'a.attr > 10 && 'a.attr > -15 &&
+      IsNotNull('a) && IsNotNull('c)).select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c,
+        'c.as('c1)).join(tr2.where(IsNotNull('x) && IsNotNull('z) && 'x.attr > -15
+      && 'z.attr + 'x.attr > 10),
+      Inner, Some("a2".attr === "x".attr && 'c1.attr === 'z.attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+    // get plan for stock spark
+    val (optimized1, _) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+    // The plans don't match as stock spark does not push down a filter of form x + z > 10
+   // comparePlans(optimized1, correctAnswer)
+  }
+
+  test("filter pruning when original attributes are lost") {
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    val y = tr.where('c.attr + 'a.attr > 10).select('a, 'a.as('x), 'b.as('y), 'c,
+      'c.as('c1)).select('x.as('x1), 'y.as('y1),
+      'c1.as('c2)).where('x1.attr + 'c2.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assertEquals(1, allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assertEquals(1, conditionalExps.size)
+    val correctAnswer = tr.where('c.attr + 'a.attr > 10 && IsNotNull('a) && IsNotNull('c)).
+      select('a, 'a.as('x), 'b.as('y), 'c,
+        'c.as('c1)).select('x.as('x1), 'y.as('y1),
+      'c1.as('c2)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning when partial attributes are lost") {
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    val y = tr.where('c.attr + 'a.attr > 10).select('a, 'a.as('x), 'b.as('y), 'c,
+      'c.as('c1)).select('c, 'x.as('x1), 'y.as('y1),
+      'c1.as('c2)).where('x1.attr + 'c.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assertEquals(1, allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assertEquals(1, conditionalExps.size)
+    val correctAnswer = tr.where('c.attr + 'a.attr > 10 && IsNotNull('a) && IsNotNull('c)).
+      select('a, 'a.as('x), 'b.as('y), 'c,
+        'c.as('c1)).select('c, 'x.as('x1), 'y.as('y1),
+      'c1.as('c2)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning with expressions in alias") {
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    val y = tr.where('c.attr + 'a.attr > 10).select('a, ('a.attr + 'c.attr).as('x),
+      'b.as('y), 'c,
+      'c.as('c1)).select('c, 'x.as('x1), 'y.as('y1),
+      'c1.as('c2)).where('x1.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assertEquals(1, allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assertEquals(1, conditionalExps.size)
+    val correctAnswer = tr.where('c.attr + 'a.attr > 10 && IsNotNull('a) && IsNotNull('c)).
+      select('a, ('a.attr + 'c.attr).as('x),
+        'b.as('y), 'c,
+        'c.as('c1)).select('c, 'x.as('x1), 'y.as('y1),
+      'c1.as('c2)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning with subexpressions in alias") {
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    val y = tr.where('c.attr + 'a.attr + 'b.attr > 10).select(('a.attr + 'c.attr).as('x),
+      'b.as('y)).select('x.as('x1), 'y.as('y1)).
+      where('x1.attr + 'y1.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    assertEquals(1, allFilters.size)
+    val conditionalExps = allFilters.head.expressions.flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assertEquals(1, conditionalExps.size)
+    val correctAnswer = tr.where('c.attr + 'a.attr + 'b.attr > 10 && IsNotNull('a) && IsNotNull('c)
+      && IsNotNull('b)).
+      select(('a.attr + 'c.attr).as('x),
+        'b.as('y)).select('x.as('x1), 'y.as('y1)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning using expression equivalence list - #1") {
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    val y = tr.where('c.attr + 'a.attr + 'b.attr > 10).select('a, 'c, ('a.attr + 'c.attr).as('x),
+      'b, 'b.as('y)).where('x.attr + 'b.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    val conditionalExps = allFilters.flatMap(_.expressions).flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assertEquals(1, conditionalExps.size)
+    val correctAnswer = tr.where('c.attr + 'a.attr + 'b.attr > 10 && IsNotNull('a) && IsNotNull('c)
+      && IsNotNull('b)).
+      select('a, 'c, ('a.attr + 'c.attr).as('x),
+        'b, 'b.as('y)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning using expression equivalence list - #2") {
+    val tr = LocalRelation('a.int, 'b.string, 'c.int)
+    val y = tr.where('c.attr + 'a.attr + 'b.attr > 10).select('c, ('a.attr + 'c.attr).as('x),
+      ('a.attr + 'c.attr).as('z), 'b, 'b.as('y)).where('x.attr + 'b.attr > 10).
+      select('z, 'y).where('z.attr + 'y.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(y)
+    val allFilters = optimized.collect[Filter] {
+      case x: Filter => x
+    }
+    val conditionalExps = allFilters.flatMap(_.expressions).flatMap(expr => expr.collect {
+      case x: GreaterThan => x
+      case y: LessThan => y
+    })
+    assertEquals(1, conditionalExps.size)
+    val correctAnswer = tr.where('c.attr + 'a.attr + 'b.attr > 10 && IsNotNull('a) && IsNotNull('c)
+      && IsNotNull('b)).select('c, ('a.attr + 'c.attr).as('x),
+      ('a.attr + 'c.attr).as('z), 'b, 'b.as('y)).select('z, 'y).analyze
+
+    comparePlans(optimized, correctAnswer)
+    val z = tr.where('c.attr + 'a.attr + 'b.attr > 10).select('c, ('a.attr + 'c.attr).as('x),
+      ('a.attr + 'c.attr).as('z), 'b, 'b.as('y)).where('x.attr + 'b.attr > 10).
+      select('z, 'y).where('z.attr + 'y.attr > 10).select(('z.attr + 'y.attr).as('k)).
+      where('k.attr > 10).analyze
+
+    val correctAnswer1 = tr.where('c.attr + 'a.attr + 'b.attr > 10 && IsNotNull('a) && IsNotNull('c)
+      && IsNotNull('b)).select('c, ('a.attr + 'c.attr).as('x),
+      ('a.attr + 'c.attr).as('z), 'b, 'b.as('y)).select('z, 'y).
+      select(('z.attr + 'y.attr).as('k)).analyze
+
+    comparePlans(GetOptimizer(OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING).execute(z), correctAnswer1)
+  }
+
+  test("check redundant constraints are not added") {
+    assume(SQLConf.get.useOptimizedConstraintPropagation)
+    val tr = LocalRelation('a.int, 'b.int, 'c.int, 'd.int)
+    val trAnalyzed = tr.analyze
+    val aliasedAnalyzed = trAnalyzed.where('c.attr + 'a.attr + 'b.attr > 10 && 'd.attr > 8).
+      select('a, 'd, 'd.attr.as('z), 'd.attr.as('z1),
+        ('a.attr + 'c.attr).as('x1), ('a.attr + 'c.attr).as('x),
+        'b, 'b.as('y), 'c).analyze
+    val y = aliasedAnalyzed.where('x.attr + 'b.attr > 10 && 'z.attr > 8).analyze
+    assert(y.resolved)
+    /* total expected constraints
+    1) a + c + b > 10  2) isnotnull(a) 3) isnotnull(b) 4) isnotnull(c)  5) d > 8
+    6) isnotnull(d) 7) a + c = x  8) b = y  9) d = z  10) isnotnull(x)
+    */
+    val expectedConstraints = ExpressionSet(Seq(
+      resolveColumn(trAnalyzed, "a") + resolveColumn(trAnalyzed, "b") +
+        resolveColumn(trAnalyzed, "c") > 10,
+      IsNotNull(resolveColumn(trAnalyzed, "a")),
+      IsNotNull(resolveColumn(trAnalyzed, "b")),
+      IsNotNull(resolveColumn(trAnalyzed, "c")),
+      IsNotNull(resolveColumn(trAnalyzed, "d")),
+     // IsNotNull(resolveColumn(aliasedAnalyzed, "x1")),
+      resolveColumn(trAnalyzed, "d") > 8,
+      resolveColumn(trAnalyzed, "a") + resolveColumn(trAnalyzed, "c") <=>
+        resolveColumn(aliasedAnalyzed, "x1"),
+      resolveColumn(trAnalyzed, "b") <=> resolveColumn(
+        aliasedAnalyzed, "y"),
+      resolveColumn(trAnalyzed, "d") <=> resolveColumn(
+        aliasedAnalyzed, "z")
+    ))
+    val constraints = y.constraints
+    assertEquals(9, constraints.size)
+    verifyConstraints(constraints, expectedConstraints)
+  }
+
+  test("new filter pushed down on Join Node with filter on each variable of join condition") {
+    val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+    val tr1_ = tr1.where('c.attr + 'a.attr > 10 && 'a.attr > -11)
+    val tr2 = LocalRelation('x.int, 'y.string, 'z.int)
+    val tr2_ = tr2.where('x.attr > -12)
+
+    val y = tr1_.select('a, 'a.as('a1), 'a.as('a2),
+      'b.as('b1), 'c,
+      'c.as('c1)).join(tr2_.select('x.as('x1)), Inner,
+      Some('a2.attr === 'x1.attr)).where('a1.attr + 'c1.attr > 10).analyze
+    assert(y.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(y)
+    val joinNode = optimized.find({
+      case _: Join => true
+      case _ => false
+    }).get.asInstanceOf[Join]
+
+    def checkForGreaterThanFunctions(node: LogicalPlan): Unit = {
+      val filterExps = node.collect {
+        case x: Filter => x
+      }.flatMap(_.expressions)
+
+      assert(filterExps.exists(x => {
+        x.find {
+          case GreaterThan(_, Literal(-12, IntegerType)) => true
+          case _ => false
+        }.isDefined
+      }))
+
+      assert(filterExps.exists(x => {
+        x.find {
+          case GreaterThan(_, Literal(-11, IntegerType)) => true
+          case _ => false
+        }.isDefined
+      }))
+    }
+
+    checkForGreaterThanFunctions(joinNode.left)
+    checkForGreaterThanFunctions(joinNode.right)
+
+    val allFilterExpressions = optimized.collect {
+      case x: Filter => x
+    }.flatMap(_.expressions)
+    assertEquals(5, allFilterExpressions.flatMap(_.collect {
+      case _: GreaterThan => true
+    }).size)
+    val correctAnswer = tr1.where('c.attr + 'a.attr > 10 && 'a.attr > -11
+      && 'a.attr > -12 && IsNotNull('a) && IsNotNull('c)).
+      select('a, 'a.as('a1), 'a.as('a2), 'b.as('b1),
+        'c, 'c.as('c1)).join(tr2.where('x.attr > -12 && IsNotNull('x) && 'x.attr > -11).
+      select('x.as('x1)), Inner,
+      Some('a2.attr === 'x1.attr)).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("filter pruning due to new filter pushed down on Join Node ") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+      val tr1_ = tr1.where('c.attr + 'a.attr > 10 && 'a.attr > -11)
+      val tr2 = LocalRelation('x.int, 'y.string, 'z.int)
+      val tr2_ = tr2.where('x.attr > -12)
+      tr1_.select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c,
+        'c.as('c1)).join(tr2_.select('x.as('x1)), Inner,
+        Some('a2.attr === 'x1.attr)).where('x1.attr + 'c1.attr > 10)
+    }
+    // The unanalyzed plan needs to be generated within the function
+    // so that sqlconf remains same within optimizer & outside
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    assert(constraints2.expand.size <= constraints1.expand.size)
+    comparePlans(plan1, plan2)
+  }
+
+  test("top filter should not be pruned for union with lower filter only on one table") {
+    val tr1 = LocalRelation('a.int, 'b.int, 'c.int)
+    val tr2 = LocalRelation('d.int, 'e.int, 'f.int)
+    val tr3 = LocalRelation('g.int, 'h.int, 'i.int)
+    val y = tr1.where('a.attr > 10).union(tr2).union(tr3.where('g.attr > 10))
+    val y1 = y.where('a.attr > 10).analyze
+    assert(y1.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING).
+      execute(y1)
+    val allFilterExpressions = optimized.collect {
+      case x: Filter => x
+    }.flatMap(_.expressions)
+    assert(allFilterExpressions.flatMap(_.collect {
+      case _: GreaterThan => true
+    }).size == 3)
+    val union = optimized.find {
+      case _: Union => true
+      case _ => false
+    }.get.asInstanceOf[Union]
+
+    val numGTExpsBelowUnion = union.children.flatMap {
+      child =>
+        child.expressions.flatMap(_.collect {
+          case x: GreaterThan => x
+        })
+    }
+    assertEquals(3, numGTExpsBelowUnion.size)
+
+    assert(union.children.forall(p => {
+      p.expressions.flatMap(_.collect {
+        case x: GreaterThan => x
+      }).nonEmpty
+    }))
+    val correctAnswer = new Union(Seq(tr1.where('a.attr > 10 && IsNotNull('a)),
+      tr2.where('d.attr > 10 && IsNotNull('d)),
+      tr3.where('g.attr > 10 && IsNotNull('g)))).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("top filter should be pruned for union with lower filter on all tables") {
+    val tr1 = LocalRelation('a.int, 'b.int, 'c.int)
+    val tr2 = LocalRelation('d.int, 'e.int, 'f.int)
+    val tr3 = LocalRelation('g.int, 'h.int, 'i.int)
+
+    val y = tr1.where('a.attr > 10).union(tr2.where('d.attr > 10)).
+      union(tr3.where('g.attr > 10))
+    val y1 = y.where('a.attr > 10).analyze
+    assert(y1.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING).
+      execute(y1)
+    val allFilterExpressions = optimized.collect {
+      case x: Filter => x
+    }.flatMap(_.expressions)
+    assert(allFilterExpressions.flatMap(_.collect {
+      case _: GreaterThan => true
+    }).size == 3)
+    val union = optimized.find {
+      case _: Union => true
+      case _ => false
+    }.get.asInstanceOf[Union]
+
+    assert(union.children.forall(p => {
+      p.expressions.flatMap(_.collect {
+        case x: GreaterThan => x
+      }).nonEmpty
+    }))
+
+    val correctAnswer = new Union(Seq(tr1.where('a.attr > 10 && IsNotNull('a)),
+      tr2.where('d.attr > 10 && IsNotNull('d)),
+      tr3.where('g.attr > 10 && IsNotNull('g)))).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("top filter should be pruned for Intersection with lower filter on one or more tables") {
+    val tr1 = LocalRelation('a.int, 'b.int, 'c.int)
+    val tr2 = LocalRelation('d.int, 'e.int, 'f.int)
+    val tr3 = LocalRelation('g.int, 'h.int, 'i.int)
+
+    val y = tr1.where('a.attr > 10).intersect(tr2.where('e.attr > 5), isAll = true).
+      intersect(tr3.where('i.attr > -5), isAll = true)
+
+    val y1 = y.select('a.attr.as("a1"), 'b.attr.as("b1"), 'c.attr.as("c1")).analyze
+    assert(y1.resolved)
+
+    val y2 = y1.where('a1.attr > 10 && 'b1.attr > 5 && 'c1.attr > -5).analyze
+    assert(y2.resolved)
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING).
+    execute(y2)
+    val allFilterExpressions = optimized.collect {
+      case x: Filter => x
+    }.flatMap(_.expressions)
+
+    assert(allFilterExpressions.flatMap(_.collect {
+      case _: GreaterThan => true
+    }).size == 3)
+    val correctAnswer = tr1.where(IsNotNull('a) && 'a.attr > 10).
+      intersect(tr2.where(IsNotNull('e) && 'e.attr > 5), isAll = true).
+      intersect(tr3.where(IsNotNull('i) && 'i.attr > -5), isAll = true).
+      select('a.attr.as("a1"), 'b.attr.as("b1"),
+        'c.attr.as("c1")).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
+  test("top filter should be pruned for aggregate with lower filter") {
+    val tr = LocalRelation('a.int, 'b.string, 'c.int, 'd.int)
+    assert(tr.analyze.constraints.isEmpty)
+    val aliasedRelation = tr.where('c.attr > 10 && 'a.attr < 5)
+      .groupBy('a, 'c, 'b)('a, 'c.as("c1"), count('a).as("a3")).
+      select('c1, 'a, 'a3).analyze
+    val withTopFilter = aliasedRelation.where('a.attr < 5 && 'c1.attr > 10 && 'a3.attr > 20).analyze
+    val optimized = GetOptimizer(OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING).
+      execute(withTopFilter)
+    val correctAnswer = tr.where('c.attr > 10 && 'a.attr < 5 && IsNotNull('a) && IsNotNull('c)
+    ).groupBy('a, 'c, 'b)('a, 'c.as("c1"), count('a).as("a3")).
+      where('a3 > Literal(20).cast(LongType)).select('c1, 'a, 'a3).analyze
+    comparePlans(correctAnswer, optimized)
+  }
+
+  test("filter push down on join with aggregate") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+      val tr2 = LocalRelation('x.int, 'y.string, 'z.int)
+      tr1.where('c.attr + 'a.attr > 10 && 'a.attr > -15).select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c, 'c.as('c1)).
+        groupBy('b1.attr, 'c1.attr)('b1, 'c1.as("c2"), count('a).as("a3")).
+        select('c2, 'a3).join(tr2.where('x.attr > 9), Inner, Some("c2".attr === "x".attr))
+    }
+
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    assert(constraints2.expand.size <= constraints1.expand.size)
+    comparePlans(plan1, plan2)
+
+
+    val conditionFinder: PartialFunction[LogicalPlan, Seq[Expression]] = {
+      case f: Filter => f.expressions.find(x => x.find {
+        case GreaterThan(att: Attribute, Literal(9, IntegerType)) if att.name == "c" => true
+        case LessThan(Literal(9, IntegerType), att: Attribute) if att.name == "c" => true
+        case _ => false
+      }.isDefined).map(Seq(_)).getOrElse(Seq.empty[Expression])
+    }
+    val result1 = plan1.collect {
+      conditionFinder
+    }.flatten
+    assert(result1.nonEmpty)
+    val result2 = plan2.collect {
+      conditionFinder
+    }.flatten
+    assert(result2.nonEmpty)
+  }
+
+  test("test pruning using constraints with filters after project - 1") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+      tr1.select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c, 'c.as('c1)).where('c.attr + 'a.attr > 10 && 'a.attr > -15).
+      where('c1.attr + 'a2.attr > 10 && 'a2.attr > -15)
+    }
+
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    assert(constraints2.expand.size <= constraints1.expand.size)
+    comparePlans(plan1, plan2)
+  }
+
+  // Not comparing with stock spark plan as stock spark plan is unoptimal
+  test("test pruning using constraints with filters after project - 2") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+      tr1.select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c, 'c.as('c1)).where('c.attr + 'a.attr > 10 && 'a.attr > -15).
+        where('c1.attr + 'a2.attr > 10 && 'a2.attr > -15)
+    }
+
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    val correctAnswer = LocalRelation('a.int, 'b.string, 'c.int).
+      select('a, 'a.as('a1), 'a.as('a2),
+      'b.as('b1), 'c, 'c.as('c1)).where('c.attr + 'a.attr > 10 && 'a.attr > -15
+       && IsNotNull('a) && IsNotNull('c)).analyze
+    comparePlans(correctAnswer, plan2)
+  }
+
+  // Not comparing with stock spark plan as stock spark plan is unoptimal
+  test("test pruning using constraints with filters after project - 3") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+      tr1.select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c, 'c.as('c1)).where('c1.attr + 'a1.attr > 10 && 'a2.attr > -15).
+        where('c.attr + 'a.attr > 10 && 'a .attr > -15)
+    }
+
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    val correctAnswer = LocalRelation('a.int, 'b.string, 'c.int).
+      select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c, 'c.as('c1)).where('c1.attr + 'a1.attr > 10 && 'a2.attr > -15
+      && IsNotNull('a) && IsNotNull('c)).analyze
+    comparePlans(correctAnswer, plan2)
+  }
+
+  test("test new filter inference with decanonicalization for expression not" +
+    " implementing NullIntolerant - 1") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.int, 'c.int)
+      tr1.select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c, 'c.as('c1),
+        CaseWhen(Seq(('a.attr + 'b.attr + 'c.attr > Literal(1),
+          Literal(1)), ('a.attr + 'b.attr + 'c.attr > Literal(2), Literal(2))),
+          Option(Literal(null))).as("z")).where('z.attr > 10 && 'a2.attr > -15).
+        where(CaseWhen(Seq(('a.attr + 'b.attr + 'c.attr > Literal(1),
+          Literal(1)), ('a.attr + 'b.attr + 'c.attr > Literal(2), Literal(2))),
+          Option(Literal(null))) > 10 && 'a.attr > -15).where('z.attr > 10)
+    }
+
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    val correctAnswer = LocalRelation('a.int, 'b.int, 'c.int).
+      select('a, 'a.as('a1), 'a.as('a2),
+       'b.as('b1), 'c, 'c.as('c1), CaseWhen(Seq(
+          ('a.attr + 'b.attr + 'c.attr > Literal(1),
+            Literal(1)), ('a.attr + 'b.attr + 'c.attr > Literal(2), Literal(2))),
+          Option(Literal(null))).as("z"), 'b).where('z.attr > 10 && 'a2.attr > -15
+      && IsNotNull('a) && IsNotNull('z)).select('a, 'a1, 'a2,
+      'b1, 'c, 'c1, 'z).analyze
+    comparePlans(correctAnswer, plan2)
+  }
+
+  test("test new filter inference with decanonicalization for expression not" +
+    " implementing NullIntolerant - 2") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.int, 'c.int)
+      tr1.select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c, 'c.as('c1),
+        ('a.attr + CaseWhen(Seq(('a.attr + 'b.attr + 'c.attr > Literal(1),
+          Literal(1)), ('a.attr + 'b.attr + 'c.attr > Literal(2), Literal(2))),
+          Option(Literal(null)))).as("z")).where('z.attr > 10 && 'a2.attr > -15).
+        where('a.attr + CaseWhen(Seq(('a.attr + 'b.attr + 'c.attr > Literal(1),
+          Literal(1)), ('a.attr + 'b.attr + 'c.attr > Literal(2), Literal(2))),
+          Option(Literal(null))) > 10 && 'a.attr > -15).where('z.attr > 10)
+    }
+
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    val correctAnswer = LocalRelation('a.int, 'b.int, 'c.int).
+      select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c, 'c.as('c1), ('a.attr + CaseWhen(Seq(
+          ('a.attr + 'b.attr + 'c.attr > Literal(1),
+            Literal(1)), ('a.attr + 'b.attr + 'c.attr > Literal(2), Literal(2))),
+          Option(Literal(null)))).as("z"), 'b).where('z.attr > 10 && 'a2.attr > -15
+      && IsNotNull('a) && IsNotNull('z)).select('a, 'a1, 'a2,
+      'b1, 'c, 'c1, 'z).analyze
+    comparePlans(correctAnswer, plan2)
+  }
+
+  test("test new filter inference with decanonicalization for expression" +
+    "implementing NullIntolerant") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.int, 'c.int)
+      tr1.select('a, 'a.as('a1), 'a.as('a2),
+       'b.as('b1), 'c, 'c.as('c1),
+        ('a.attr + 'b.attr + 'c.attr ).as("z")).where('z.attr > 10 && 'a2.attr > -15).
+        where('a.attr + 'b1.attr + 'c.attr > 10 && 'a.attr > -15)
+    }
+
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    val correctAnswer = LocalRelation('a.int, 'b.int, 'c.int).
+      select('a, 'a.as('a1), 'a.as('a2),
+        'b.as('b1), 'c, 'c.as('c1),
+        ('a.attr + 'b.attr + 'c.attr ).as("z")).where('z.attr > 10 && 'a2.attr > -15
+      && IsNotNull('a) && IsNotNull('b1) && IsNotNull('c)).analyze
+    comparePlans(correctAnswer, plan2)
+  }
+
+  test("test pruning using constraints with filters after project with expression in" +
+    " alias.") {
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.int, 'c.int)
+      tr1.select('a, 'a.as('a1), 'a.as('a2), 'b,
+        'b.as('b1), 'c, 'c.as('c1), ('a.attr + 'b.attr).as("z")).
+        where('c1.attr + 'z.attr > 10 &&
+          'a2.attr > -15).
+        where('c.attr + 'a.attr + 'b.attr > 10 &&
+          'a.attr > -15)
+    }
+
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    val correctAnswer = LocalRelation('a.int, 'b.int, 'c.int).
+      select('a, 'a.as('a1), 'a.as('a2), 'b,
+        'b.as('b1), 'c, 'c.as('c1), ('a.attr + 'b.attr).as("z")).
+      where('c1.attr + 'z.attr > 10 &&
+        'a2.attr > -15 && IsNotNull('b)
+        && IsNotNull('a) && IsNotNull('c)).analyze
+    comparePlans(correctAnswer, plan2)
+  }
+
+  ignore("Disabled due to spark's canonicalization bug." +
+    " test pruning using constraints with filters after project with expression in alias.") {
+
+    def getTestPlan: LogicalPlan = {
+      val tr1 = LocalRelation('a.int, 'b.string, 'c.int)
+      tr1.select('a, 'a.as('a1), 'a.as('a2), 'b,
+        'b.as('b1), 'c, 'c.as('c1), ('a.attr + 'b.attr).as("z")).
+        where('c1.attr + 'z.attr > 10 && 'a2.attr > -15).
+        where('c.attr + 'a.attr + 'b.attr > 10 && 'a.attr > -15)
+    }
+
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+    val correctAnswer = LocalRelation('a.int, 'b.string, 'c.int).
+      select('a, 'a.as('a1), 'a.as('a2), 'b,
+        'b.as('b1), 'c, 'c.as('c1), ('a.attr + 'b.attr).as("z")).
+      where('c1.attr + 'z.attr > 10 && 'a2.attr > -15
+      && IsNotNull('a) && IsNotNull('c) && IsNotNull('b)).analyze
+    comparePlans(correctAnswer, plan2)
+  }
+
+  test("plan equivalence with case statements") {
+    def getTestPlan: LogicalPlan = {
+      val tr = LocalRelation('a.int, 'b.int, 'c.int, 'd.int, 'e.int, 'f.int, 'g.int, 'h.int, 'i.int,
+        'j.int, 'k.int, 'l.int, 'm.int, 'n.int)
+      tr.select('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l, 'm, 'n,
+        CaseWhen(Seq(('a.attr + 'b.attr + 'c.attr + 'd.attr + 'e.attr + 'f.attr + 'g.attr
+          + 'h.attr + 'i.attr + 'j.attr + 'k.attr + 'l.attr + 'm.attr + 'n.attr > Literal(1),
+          Literal(1)),
+          ('a.attr + 'b.attr + 'c.attr + 'd.attr + 'e.attr + 'f.attr + 'g.attr + 'h.attr +
+            'i.attr + 'j.attr + 'k.attr + 'l.attr + 'm.attr + 'n.attr > Literal(2), Literal(2))),
+          Option(Literal(0))).as("JoinKey1")
+      ).select('a.attr.as("a1"), 'b.attr.as("b1"), 'c.attr.as("c1"),
+        'd.attr.as("d1"), 'e.attr.as("e1"), 'f.attr.as("f1"),
+        'g.attr.as("g1"), 'h.attr.as("h1"), 'i.attr.as("i1"),
+        'j.attr.as("j1"), 'k.attr.as("k1"), 'l.attr.as("l1"),
+        'm.attr.as("m1"), 'n.attr.as("n1"), 'JoinKey1.attr.as("cf1"),
+        'JoinKey1.attr).select('a1, 'b1, 'c1, 'd1, 'e1, 'f1, 'g1, 'h1, 'i1, 'j1, 'k1,
+        'l1, 'm1, 'n1, 'cf1, 'JoinKey1).join(tr, condition = Option('a.attr <=> 'JoinKey1.attr))
+    }
+    val (plan1, constraints1) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    val (plan2, constraints2) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    assert(constraints1 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+
+    assert(constraints2 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+
+    // Due to proper tracking of aliases, it is possible that final number of constraints
+    // may be a liitle more than the number of constraints returned by old code
+    // but intermediate size of old code may be very large causing issue, which is
+    // eliminated in the new code. The reason why this happens is that in the
+    //  ConstraintSet code to allow proper pruning from canonicalization, it is
+    // possible that the incoming expression may be expanded into its constituents
+    // refer function ConstraintSet.convertToCanonicalizedIfRqeuired
+    // where we are expanding using expression list also.
+    // assert(constraints2.expand.size <= constraints1.expand.size)
+    comparePlans(plan1, plan2)
+
+    val (plan3, constraints3) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "false") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+
+    val (plan4, constraints4) = withSQLConf[(LogicalPlan, ExpressionSet)](
+      SQLConf.OPTIMIZER_OPTIMIZED_CONSTRAINT_PROPAGATION.key -> "true") {
+      executePlan(getTestPlan, OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING)
+    }
+    assert(constraints3 match {
+      case _: ConstraintSet => false
+      case _: ExpressionSet => true
+    })
+    assert(constraints4 match {
+      case _: ConstraintSet => true
+      case _: ExpressionSet => false
+    })
+   // assert(constraints4.expand.size <= constraints3.expand.size)
+    comparePlans(plan3, plan4)
+  }
+
+  def executePlan(plan: LogicalPlan, optimizerType: OptimizerTypes.Value):
+  (LogicalPlan, ExpressionSet) = {
+    object SimpleAnalyzer extends Analyzer(
+      new SessionCatalog(
+        new InMemoryCatalog,
+        EmptyFunctionRegistry,
+        SQLConf.get), SQLConf.get)
+
+
+    val optimizedPlan = GetOptimizer(optimizerType, Some(SQLConf.get)).
+      execute(SimpleAnalyzer.execute(plan))
+    (optimizedPlan, optimizedPlan.constraints)
+  }
+}
+
+object OptimizerTypes extends Enumeration {
+  val WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING,
+  NO_PUSH_DOWN_ONLY_PRUNING, WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING = Value
+}
+
+object GetOptimizer {
+  def apply(optimizerType: OptimizerTypes.Value, useConf: Option[SQLConf] = None): Optimizer =
+    optimizerType match {
+      case OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_PRUNING =>
+        new Optimizer(new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+          useConf.getOrElse(SQLConf.get))) {
+          override def defaultBatches: Seq[Batch] =
+            Batch("Subqueries", Once,
+              EliminateSubqueryAliases) ::
+              Batch("Filter Pushdown and Pruning", FixedPoint(100),
+                PushPredicateThroughJoin,
+                PushDownPredicate,
+                InferFiltersFromConstraints,
+                CombineFilters,
+                PruneFilters) :: Nil
+
+          override def nonExcludableRules: Seq[String] = Seq.empty[String]
+        }
+
+      case OptimizerTypes.NO_PUSH_DOWN_ONLY_PRUNING =>
+        new Optimizer(new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+          useConf.getOrElse(SQLConf.get))) {
+          override def defaultBatches: Seq[Batch] =
+            Batch("Subqueries", Once,
+              EliminateSubqueryAliases) ::
+              Batch("Filter Pruning", Once,
+                InferFiltersFromConstraints,
+                // CombineFilters,
+                PruneFilters) :: Nil
+
+          override def nonExcludableRules: Seq[String] = Seq.empty[String]
+        }
+
+      case OptimizerTypes.WITH_FILTER_PUSHDOWN_THRU_JOIN_AND_UNIONS_PRUNING =>
+        new Optimizer(new SessionCatalog(new InMemoryCatalog, EmptyFunctionRegistry,
+          useConf.getOrElse(SQLConf.get))) {
+          override def defaultBatches: Seq[Batch] =
+            Batch("Subqueries", Once,
+              EliminateSubqueryAliases) ::
+              Batch("Union Pushdown", FixedPoint(100),
+                CombineUnions,
+                PushProjectionThroughUnion,
+                PushDownPredicate,
+                InferFiltersFromConstraints,
+                CombineFilters,
+                PruneFilters) :: Nil
+
+          override def nonExcludableRules: Seq[String] = Seq.empty[String]
+        }
+    }
+  }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -51,7 +51,7 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
     spark = null
   }
 
-  override def withSQLConf(pairs: (String, String)*)(f: => Unit): Unit = {
+  override def withSQLConf[T](pairs: (String, String)*)(f: => T): T = {
     pairs.foreach { case (k, v) =>
       SQLConf.get.setConfString(k, v)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -162,7 +162,7 @@ private[sql] trait SQLTestUtilsBase
     protected override def _sqlContext: SQLContext = self.spark.sqlContext
   }
 
-  protected override def withSQLConf(pairs: (String, String)*)(f: => Unit): Unit = {
+  protected override def withSQLConf[T](pairs: (String, String)*)(f: => T): T = {
     SparkSession.setActiveSession(spark)
     super.withSQLConf(pairs: _*)(f)
   }


### PR DESCRIPTION
…s or compilation time to go in minutes/hours

 ### What changes were proposed in this pull request?

    This PR proposes new logic to store the constraint and track aliases in projection which eliminates the need of pessimistically generating all the permutations of a given constraint. It is also more effective in correctly identifying the filters which can be pruned, apart from minimizing the memory used as compared to the current code. This also has changes to push compound filters if the join condition is on multiple attributes and the constraint comprises of more than 1 attributes of the join conditions.

### Why are the changes needed?

    This issue if not fixed can cause OutOfMemory issue or unacceptable query compilation times.

 ### Does this PR introduce _any_ user-facing change?

   No. The behavior remains completely unchanged

 ### How was this patch tested?

    Ran the /dev/run-tests. Added targeted tests in OptimizedConstraintPropagationSuite

    Closes #33152

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
